### PR TITLE
Improve things 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ run:
 
 # Run tests
 test:
-	go test -race -v ./...
+	GOCACHE=off go test -race -v ./...
 .PHONY: test
 
 # Run tests and show code coverage

--- a/client/cachet.go
+++ b/client/cachet.go
@@ -4,6 +4,7 @@ import (
 	"github.com/andygrunwald/cachet"
 )
 
+// Client manages communication with the Cachet API.
 type Client interface {
 	GetAllComponentGroups() ([]cachet.ComponentGroup, error)
 	GetAllIncidentsByStatus(status int) ([]cachet.Incident, error)
@@ -13,6 +14,7 @@ type cachetClient struct {
 	client *cachet.Client
 }
 
+// NewCachetClient returns an initialized Cachet API client
 func NewCachetClient(apiURL string) (Client, error) {
 	client, err := cachet.NewClient(apiURL, nil)
 	if err != nil {

--- a/client/cachet.go
+++ b/client/cachet.go
@@ -7,26 +7,10 @@ import (
 type Client interface {
 	GetAllComponentGroups() ([]cachet.ComponentGroup, error)
 	GetAllIncidentsByStatus(status int) ([]cachet.Incident, error)
-	Ping() (float64, error)
 }
 
 type cachetClient struct {
 	client *cachet.Client
-}
-
-func (c *cachetClient) GetAllComponentGroups() ([]cachet.ComponentGroup, error) {
-	groups, _, err := c.client.ComponentGroups.GetAll(&cachet.ComponentGroupsQueryParams{})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return groups.ComponentGroups, nil
-}
-
-func (c *cachetClient) Ping() (float64, error) {
-	_, _, err := c.client.General.Ping()
-	return 1, err
 }
 
 func NewCachetClient(apiURL string) (Client, error) {
@@ -40,9 +24,17 @@ func NewCachetClient(apiURL string) (Client, error) {
 	}, nil
 }
 
+func (c *cachetClient) GetAllComponentGroups() ([]cachet.ComponentGroup, error) {
+	groups, _, err := c.client.ComponentGroups.GetAll(&cachet.ComponentGroupsQueryParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	return groups.ComponentGroups, nil
+}
+
 func (c *cachetClient) GetAllIncidentsByStatus(status int) ([]cachet.Incident, error) {
 	incidents, _, err := c.client.Incidents.GetAll(&cachet.IncidentsQueryParams{Status: status})
-
 	if err != nil {
 		return nil, err
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -73,16 +73,12 @@ func (c *cachetCollector) Collect(ch chan<- prometheus.Metric) {
 
 	start := time.Now()
 	log.Info("Collecting metrics from Cachet")
-	_, err := c.client.Ping()
-	if err != nil {
-		ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 0)
-		log.With("error", err).Error("failed to scrape Cachet")
-		return
-	}
 
 	groups, err := c.client.GetAllComponentGroups()
 	if err != nil {
+		ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 0)
 		log.With("error", err).Error("failed to scrape Group Components")
+		return
 	}
 
 	incidents := map[int][]cachet.Incident{

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -81,21 +81,21 @@ func (c *cachetCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	groups, err := c.client.GetAllComponentGroups()
-
 	if err != nil {
 		log.With("error", err).Error("failed to scrape Group Components")
 	}
 
 	incidents := map[int][]cachet.Incident{
+		0: c.getIncidentsByStatus(0),
 		1: c.getIncidentsByStatus(1),
 		2: c.getIncidentsByStatus(2),
 		3: c.getIncidentsByStatus(3),
+		4: c.getIncidentsByStatus(4),
 	}
 
 	for _, group := range groups {
 		c.createComponentsMetric(group, ch)
 		c.createIncidentsTotalMetric(group, incidents, ch)
-
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, 1)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -118,6 +118,7 @@ func (c *cachetCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (c *cachetCollector) createComponentsMetric(group cachet.ComponentGroup, ch chan<- prometheus.Metric) {
 	componentsByStatus := map[int][]cachet.Component{
+		0: make([]cachet.Component, 0),
 		1: make([]cachet.Component, 0),
 		2: make([]cachet.Component, 0),
 		3: make([]cachet.Component, 0),

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,10 +17,10 @@ type cachetCollector struct {
 	mutex  sync.RWMutex
 	client client.Client
 
-	up              *prometheus.Desc
-	scrapeDuration  *prometheus.Desc
-	incidentsTotal  *prometheus.Desc
-	componentsTotal *prometheus.Desc
+	up             *prometheus.Desc
+	scrapeDuration *prometheus.Desc
+	incidents      *prometheus.Desc
+	components     *prometheus.Desc
 }
 
 // NewCachetCollector returns a prometheus collector which exports
@@ -40,15 +40,15 @@ func NewCachetCollector(client client.Client) prometheus.Collector {
 			nil,
 			nil,
 		),
-		incidentsTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "incidents_total"),
-			"Total of incidents by status",
+		incidents: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "incidents"),
+			"Number of incidents by status",
 			[]string{"status", "group_name", "component_name"},
 			nil,
 		),
-		componentsTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "components_total"),
-			"Total of components by status",
+		components: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "components"),
+			"Number of components by status",
 			[]string{"status", "group_name"},
 			nil,
 		),
@@ -60,7 +60,8 @@ func NewCachetCollector(client client.Client) prometheus.Collector {
 func (c *cachetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.up
 	ch <- c.scrapeDuration
-	ch <- c.incidentsTotal
+	ch <- c.incidents
+	ch <- c.components
 }
 
 // Collect fetches the metrics data from the Cachet application and
@@ -114,7 +115,7 @@ func (c *cachetCollector) createComponentsMetric(group cachet.ComponentGroup, ch
 	}
 
 	for status, components := range componentsStatus {
-		ch <- prometheus.MustNewConstMetric(c.componentsTotal, prometheus.GaugeValue, float64(len(components)), strconv.Itoa(status), group.Name)
+		ch <- prometheus.MustNewConstMetric(c.components, prometheus.GaugeValue, float64(len(components)), strconv.Itoa(status), group.Name)
 	}
 }
 
@@ -140,7 +141,7 @@ func (c *cachetCollector) createIncidentsTotalMetricByComponent(group cachet.Com
 				componentIncidents = append(componentIncidents, incident)
 			}
 		}
-		ch <- prometheus.MustNewConstMetric(c.incidentsTotal, prometheus.GaugeValue, float64(len(componentIncidents)), strconv.Itoa(status), group.Name, component.Name)
+		ch <- prometheus.MustNewConstMetric(c.incidents, prometheus.GaugeValue, float64(len(componentIncidents)), strconv.Itoa(status), group.Name, component.Name)
 	}
 
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -13,16 +13,6 @@ import (
 
 const namespace = "cachet"
 
-type metricConfig struct {
-	Name   string            `yaml:"metric_name"`
-	Labels map[string]string `yaml:"labels"`
-}
-
-// Config is the struct used to load the configurations from yaml file
-type Config struct {
-	Metrics []metricConfig `yaml:"metrics"`
-}
-
 type cachetCollector struct {
 	mutex  sync.RWMutex
 	client client.Client

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -80,7 +80,7 @@ func TestCollectCachetIncidents(t *testing.T) {
 
 	metrics := getMetrics("cachet_incidents", ch)
 	assert.NotNil(t, metrics)
-	assert.Len(t, metrics, 5)
+	assert.Len(t, metrics, 10)
 
 	var metricTests = []metricTest{
 		{incidentStatus[0], 0},

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -74,10 +74,10 @@ func TestCollectCachetIncidents(t *testing.T) {
 		collector.Collect(ch)
 		close(ch)
 	}()
-	metric := getMetrics("cachet_incidents", ch)[0]
 
-	assert.NotNil(t, metric)
-	assert.Equal(t, float64(10), *metric.GetGauge().Value)
+	metrics := getMetrics("cachet_incidents", ch)
+	assert.NotNil(t, metrics)
+	assert.Len(t, metrics, 5)
 }
 
 func TestCollectCachetComponents(t *testing.T) {
@@ -89,11 +89,8 @@ func TestCollectCachetComponents(t *testing.T) {
 		close(ch)
 	}()
 	metrics := getMetrics("cachet_components", ch)
-	assert.NotNil(t, metrics[1])
-	assert.Equal(t, float64(0), *metrics[0].GetGauge().Value)
-	assert.Equal(t, float64(1), *metrics[1].GetGauge().Value)
-	assert.Equal(t, float64(0), *metrics[2].GetGauge().Value)
-	assert.Equal(t, float64(0), *metrics[3].GetGauge().Value)
+	assert.NotNil(t, metrics)
+	assert.Len(t, metrics, 5)
 }
 
 func getMetrics(key string, ch <-chan prometheus.Metric) []*dto.Metric {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -22,11 +22,9 @@ type dummyClient struct {
 }
 
 func (d *dummyClient) GetAllComponentGroups() ([]cachet.ComponentGroup, error) {
-	components := []cachet.Component{cachet.Component{
-		ID:     1,
-		Name:   "Component",
-		Status: 2,
-	}}
+	components := []cachet.Component{
+		cachet.Component{ID: 1, Name: "Component One", Status: 2},
+		cachet.Component{ID: 2, Name: "Component Two", Status: 4}}
 	return []cachet.ComponentGroup{cachet.ComponentGroup{EnabledComponents: components}}, nil
 }
 
@@ -113,7 +111,7 @@ func TestCollectCachetComponents(t *testing.T) {
 		{componentStatus[1], 0},
 		{componentStatus[2], 1},
 		{componentStatus[3], 0},
-		{componentStatus[4], 0},
+		{componentStatus[4], 1},
 	}
 	for _, mt := range metricTests {
 		assertMetric(t, metrics, mt)

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, // nolint: gas
+		fmt.Fprintf(w, // nolint: gas, errcheck
 			`
 			<html>
 			<head><title>Cachet Exporter</title></head>


### PR DESCRIPTION
When added this exporter to the official Prometheus documentation, @brian-brazil suggested A few tips to improve things: https://github.com/prometheus/docs/pull/1165#issuecomment-419013081

What I did:
- Removed the Ping method (and removed all related code) and set `cachet_up` as `1` only after all Cachet requests
- Removed old config codes
- Removed the `_total` suffix from metrics names
- Used status name instead of ID for the label `status`
- Added missing incidents and component statuses

@ContaAzul/sre 