### PR TITLE
Change base image from scratch to GCR's distroless base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/distroless/base
 EXPOSE 9470
 WORKDIR /
 COPY cachet_exporter .


### PR DESCRIPTION
We need cacerts configuration in order to communicate with cachet under https. GCR's distroless (https://github.com/GoogleContainerTools/distroless/tree/master/base) is a lightweight container image prepared for Golang applications plus pre-configured cacerts
